### PR TITLE
Add workflow query support and status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ python manage.py durable_start onboard_user --input '{"user_id": 7}'
 python manage.py durable_worker --batch 20 --tick 0.2
 ```
 
+## Queries
+
+- Inspect running workflow state via CLI:
+
+```bash
+python manage.py durable_status <execution_uuid>
+```
+
+- Programmatically:
+
+```python
+from django_durable.engine import query_workflow
+info = query_workflow(execution_id, 'status')
+```
+
 ## Signals
 
 - In code, a workflow can wait for signals using `ctx.wait_signal("signal_name")`, which pauses execution until a matching signal arrives and returns its payload.

--- a/django_durable/engine.py
+++ b/django_durable/engine.py
@@ -618,3 +618,36 @@ def send_signal(execution: Union[WorkflowExecution, str], name: str, payload: An
             WorkflowExecution.objects.filter(pk=execution.pk).update(
                 status=WorkflowExecution.Status.PENDING
             )
+
+
+def query_workflow(execution: Union[WorkflowExecution, str], name: str, **payload):
+    """Execute a registered read-only query against a workflow.
+
+    A default ``status`` query is always available returning basic
+    information about the execution.
+    """
+
+    if not isinstance(execution, WorkflowExecution):
+        execution = WorkflowExecution.objects.get(pk=execution)
+
+    fn = register.queries.get(execution.workflow_name, {}).get(name)
+    if fn is not None:
+        return fn(execution, **payload)
+
+    if name == 'status':
+        pending = list(
+            execution.activities.filter(status=ActivityTask.Status.QUEUED)
+            .values('id', 'activity_name', 'pos')
+        )
+        return {
+            'id': str(execution.id),
+            'workflow_name': execution.workflow_name,
+            'status': execution.status,
+            'result': execution.result,
+            'error': execution.error,
+            'pending_activities': pending,
+        }
+
+    raise KeyError(
+        f"Unknown query '{name}' for workflow '{execution.workflow_name}'"
+    )

--- a/django_durable/management/commands/durable_status.py
+++ b/django_durable/management/commands/durable_status.py
@@ -1,0 +1,41 @@
+import json
+from django.core.management.base import BaseCommand, CommandError
+
+from django_durable.models import WorkflowExecution
+from django_durable.engine import query_workflow
+
+
+class Command(BaseCommand):
+    help = 'Query a workflow execution for its current state.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('execution_id', help='WorkflowExecution UUID')
+        parser.add_argument(
+            '--query', default='status', help='Query name (default: status)'
+        )
+        parser.add_argument(
+            '--input', default='{}', help='JSON kwargs for the query (default: {})'
+        )
+
+    def handle(self, *args, **opts):
+        exec_id = opts['execution_id']
+        query_name = opts['query']
+        try:
+            payload = json.loads(opts['input'])
+            if not isinstance(payload, dict):
+                raise ValueError('Query input must be a JSON object')
+        except Exception as e:
+            raise CommandError(f'Invalid JSON for --input: {e}')
+
+        try:
+            wf = WorkflowExecution.objects.get(pk=exec_id)
+        except WorkflowExecution.DoesNotExist:
+            raise CommandError(f'WorkflowExecution not found: {exec_id}')
+
+        try:
+            res = query_workflow(wf, query_name, **payload)
+        except KeyError as e:
+            raise CommandError(str(e))
+
+        self.stdout.write(json.dumps(res))
+

--- a/django_durable/registry.py
+++ b/django_durable/registry.py
@@ -6,12 +6,23 @@ class Register:
     def __init__(self):
         self.workflows: Dict[str, Callable] = {}
         self.activities: Dict[str, Callable] = {}
+        self.queries: Dict[str, Dict[str, Callable]] = {}
 
     def workflow(self, name: Optional[str] = None, timeout: Optional[float] = None):
         def deco(fn):
             if timeout is not None:
                 fn._durable_timeout = timeout
             self.workflows[name or fn.__name__] = fn
+            return fn
+
+        return deco
+
+    def query(self, workflow_name: str, name: Optional[str] = None):
+        """Register a read-only query handler for a workflow."""
+
+        def deco(fn: Callable):
+            wf_queries = self.queries.setdefault(workflow_name, {})
+            wf_queries[name or fn.__name__] = fn
             return fn
 
         return deco

--- a/testproj/durable_workflows.py
+++ b/testproj/durable_workflows.py
@@ -29,6 +29,12 @@ def e2e_flow(ctx, value):
     return {"res": res["value"], "sig": sig}
 
 
+@register.query("e2e_flow")
+def history(execution):
+    """Return the number of history events for this execution."""
+    return {"events": execution.history.count()}
+
+
 @register.workflow()
 def complex_flow(ctx, value):
     # chain multiple activities with timers and a signal

--- a/testproj/tests/test_queries.py
+++ b/testproj/tests/test_queries.py
@@ -1,0 +1,50 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANAGE = str(ROOT / "manage.py")
+
+
+def run_manage(*args, check=True):
+    cmd = [sys.executable, MANAGE, *args]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if check and res.returncode != 0:
+        raise AssertionError(
+            f"Command failed: {' '.join(cmd)}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
+        )
+    return res.stdout.strip()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def migrate_db():
+    run_manage("migrate", "--noinput")
+
+
+def test_status_and_custom_query(tmp_path):
+    run_manage("flush", "--noinput")
+    # Start workflow and progress to signal wait
+    out = run_manage(
+        "durable_start", "e2e_flow", "--input", json.dumps({"value": 5})
+    )
+    exec_id = out.splitlines()[-1].strip()
+
+    run_manage(
+        "durable_worker", "--batch", "50", "--tick", "0.01", "--iterations", "10"
+    )
+
+    # Default status query
+    res = run_manage("durable_status", exec_id)
+    data = json.loads(res)
+    assert data["status"] == "WAITING"
+    assert data["workflow_name"] == "e2e_flow"
+
+    # Custom history query registered for e2e_flow
+    res = run_manage("durable_status", exec_id, "--query", "history")
+    data = json.loads(res)
+    assert data["events"] > 0
+


### PR DESCRIPTION
## Summary
- allow workflows to expose read-only queries via new registry API
- provide engine `query_workflow` helper and `durable_status` management command
- document query usage and test status and custom queries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3908d53908330bfef3fdb5929b592