### PR TITLE
Ensure workflows resume after worker crashes

### DIFF
--- a/testproj/durable_activities.py
+++ b/testproj/durable_activities.py
@@ -71,7 +71,21 @@ def heartbeat_activity():
     return {"ok": True}
 
 
-@register.activity(heartbeat_timeout=0.1)
+@register.activity(heartbeat_timeout=0.1, max_retries=1)
 def no_heartbeat_activity(delay=0.2):
     sleep(delay)
     return {"ok": True}
+
+@register.activity(
+    timeout=1.0,
+    retry_policy=RetryPolicy(
+        initial_interval=0.1,
+        backoff_coefficient=2.0,
+        maximum_interval=1.0,
+        maximum_attempts=0,
+    ),
+)
+def slow_sleep(delay=0.2):
+    """Activity that sleeps for a bit to simulate long work."""
+    sleep(delay)
+    return {"slept": delay}

--- a/testproj/durable_workflows.py
+++ b/testproj/durable_workflows.py
@@ -96,3 +96,20 @@ def child_increment_workflow(ctx, x: int):
 def parent_child_workflow(ctx, x: int):
     child = ctx.workflow("child_increment_workflow", x=x)
     return {"child": child}
+
+@register.workflow()
+def long_running_step_flow(ctx, loops: int, delay: float):
+    """Workflow with long-running steps to test recovery when worker dies mid-execution."""
+    import time
+    for i in range(loops):
+        time.sleep(delay)
+        ctx.activity("do_work", i)
+    return {"done": loops}
+
+
+@register.workflow()
+def long_activity_flow(ctx, loops: int, delay: float):
+    """Workflow with slow activities to test recovery when worker dies during an activity."""
+    for _ in range(loops):
+        ctx.activity("slow_sleep", delay)
+    return {"done": loops}

--- a/testproj/tests/test_e2e.py
+++ b/testproj/tests/test_e2e.py
@@ -81,7 +81,7 @@ def test_signal_flow_completes(tmp_path):
     run_manage("durable_worker", "--batch", "50", "--tick", "0.01", "--iterations", "10")
 
     status, result = read_workflow(exec_id)
-    assert status == "WAITING"
+    assert status == "RUNNING"
     assert result is None
 
     # Send signal and resume to completion
@@ -138,7 +138,7 @@ def test_complex_flow_runs_end_to_end(tmp_path):
     run_manage("durable_worker", "--batch", "50", "--tick", "0.01", "--iterations", "20")
 
     status, result = read_workflow(exec_id)
-    assert status == "WAITING"
+    assert status == "RUNNING"
     assert result is None
 
     # Send signal and resume workflow to completion

--- a/testproj/tests/test_queries.py
+++ b/testproj/tests/test_queries.py
@@ -40,7 +40,7 @@ def test_status_and_custom_query(tmp_path):
     # Default status query
     res = run_manage("durable_status", exec_id)
     data = json.loads(res)
-    assert data["status"] == "WAITING"
+    assert data["status"] == "RUNNING"
     assert data["workflow_name"] == "e2e_flow"
 
     # Custom history query registered for e2e_flow

--- a/testproj/tests/test_timeouts_retries.py
+++ b/testproj/tests/test_timeouts_retries.py
@@ -67,6 +67,7 @@ def read_activity_statuses(exec_id):
 
 
 def test_activity_timeout(tmp_path):
+    run_manage("flush", "--noinput")
     out = run_manage("durable_start", "activity_timeout_flow")
     exec_id = out.splitlines()[-1].strip()
     run_manage("durable_worker", "--batch", "50", "--tick", "0.01", "--iterations", "5")
@@ -93,6 +94,7 @@ def test_workflow_timeout(tmp_path):
 
 
 def test_retry_policy(tmp_path):
+    run_manage("flush", "--noinput")
     out = run_manage(
         "durable_start",
         "retry_flow",

--- a/testproj/tests/test_worker_resilience.py
+++ b/testproj/tests/test_worker_resilience.py
@@ -1,0 +1,147 @@
+import json
+import random
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+MANAGE = str(ROOT / "manage.py")
+DB_PATH = str(ROOT / "db.sqlite3")
+
+
+def run_manage(*args, check=True):
+    cmd = [sys.executable, MANAGE, *args]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if check and res.returncode != 0:
+        raise AssertionError(
+            f"Command failed: {' '.join(cmd)}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
+        )
+    return res.stdout.strip()
+
+
+def read_workflow(exec_id):
+    con = sqlite3.connect(DB_PATH)
+    try:
+        cur = con.cursor()
+        norm = exec_id.replace('-', '')
+        cur.execute(
+            "SELECT status FROM django_durable_workflowexecution WHERE id=?",
+            (norm,),
+        )
+        row = cur.fetchone()
+        assert row, f"Workflow not found: {exec_id}"
+        return row[0]
+    finally:
+        con.close()
+
+
+def running_counts():
+    con = sqlite3.connect(DB_PATH)
+    try:
+        cur = con.cursor()
+        cur.execute(
+            "SELECT COUNT(*) FROM django_durable_workflowexecution WHERE status='RUNNING'"
+        )
+        wf = cur.fetchone()[0]
+        cur.execute(
+            "SELECT COUNT(*) FROM django_durable_activitytask WHERE status='RUNNING'"
+        )
+        act = cur.fetchone()[0]
+        return wf, act
+    finally:
+        con.close()
+
+
+def start_worker():
+    return subprocess.Popen(
+        [sys.executable, MANAGE, "durable_worker", "--batch", "5", "--tick", "0.05"]
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def migrate_db():
+    run_manage("migrate", "--noinput")
+
+
+@pytest.mark.slow
+def test_worker_killed_during_workflow(tmp_path):
+    run_manage("flush", "--noinput")
+    exec_ids = []
+    for _ in range(5):
+        out = run_manage(
+            "durable_start",
+            "long_running_step_flow",
+            "--input",
+            json.dumps({"loops": 3, "delay": 0.2}),
+        )
+        exec_ids.append(out.splitlines()[-1].strip())
+
+    workers = [start_worker() for _ in range(3)]
+    rnd = random.Random(0)
+    start = time.time()
+    deadline = start + 60
+    try:
+        while time.time() < deadline:
+            statuses = [read_workflow(eid) for eid in exec_ids]
+            if all(s == "COMPLETED" for s in statuses):
+                break
+            _, act_running = running_counts()
+            if act_running == 0 and rnd.random() < 0.3:
+                victim = rnd.choice(workers)
+                victim.kill()
+                victim.wait(timeout=5)
+                workers.remove(victim)
+                workers.append(start_worker())
+            time.sleep(0.1)
+        assert all(read_workflow(eid) == "COMPLETED" for eid in exec_ids)
+    finally:
+        for p in workers:
+            p.terminate()
+            try:
+                p.wait(timeout=5)
+            except Exception:
+                p.kill()
+
+
+@pytest.mark.slow
+def test_worker_killed_during_activity(tmp_path):
+    run_manage("flush", "--noinput")
+    exec_ids = []
+    for _ in range(5):
+        out = run_manage(
+            "durable_start",
+            "long_activity_flow",
+            "--input",
+            json.dumps({"loops": 3, "delay": 0.2}),
+        )
+        exec_ids.append(out.splitlines()[-1].strip())
+
+    workers = [start_worker() for _ in range(3)]
+    rnd = random.Random(1)
+    start = time.time()
+    deadline = start + 60
+    try:
+        while time.time() < deadline:
+            statuses = [read_workflow(eid) for eid in exec_ids]
+            if all(s == "COMPLETED" for s in statuses):
+                break
+            _, act_running = running_counts()
+            if act_running > 0 and rnd.random() < 0.1:
+                victim = rnd.choice(workers)
+                victim.kill()
+                victim.wait(timeout=5)
+                workers.remove(victim)
+                workers.append(start_worker())
+            time.sleep(0.1)
+        assert all(read_workflow(eid) == "COMPLETED" for eid in exec_ids)
+    finally:
+        for p in workers:
+            p.terminate()
+            try:
+                p.wait(timeout=5)
+            except Exception:
+                p.kill()


### PR DESCRIPTION
## Summary
- rely on activity timeouts, heartbeats and retry policy instead of resetting stalled tasks
- run workflows synchronously until an activity is scheduled and treat waiting state as RUNNING
- expand tests to cover timeouts, retries and worker restarts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47452fefc83308147c45c826e0ba5