### PR TITLE
refactor: extract constants for event types

### DIFF
--- a/django_durable/constants.py
+++ b/django_durable/constants.py
@@ -1,0 +1,35 @@
+from enum import Enum
+
+class HistoryEventType(str, Enum):
+    VERSION_MARKER = "version_marker"
+    ACTIVITY_SCHEDULED = "activity_scheduled"
+    ACTIVITY_COMPLETED = "activity_completed"
+    ACTIVITY_FAILED = "activity_failed"
+    ACTIVITY_TIMED_OUT = "activity_timed_out"
+    SIGNAL_ENQUEUED = "signal_enqueued"
+    SIGNAL_WAIT = "signal_wait"
+    SIGNAL_CONSUMED = "signal_consumed"
+    CHILD_WORKFLOW_SCHEDULED = "child_workflow_scheduled"
+    CHILD_WORKFLOW_COMPLETED = "child_workflow_completed"
+    CHILD_WORKFLOW_FAILED = "child_workflow_failed"
+    WORKFLOW_STARTED = "workflow_started"
+    WORKFLOW_COMPLETED = "workflow_completed"
+    WORKFLOW_FAILED = "workflow_failed"
+    WORKFLOW_CANCELED = "workflow_canceled"
+    WORKFLOW_TIMED_OUT = "workflow_timed_out"
+
+
+class ErrorCode(str, Enum):
+    ACTIVITY_FAILED = "activity_failed"
+    ACTIVITY_TIMEOUT = "activity_timeout"
+    WORKFLOW_TIMEOUT = "workflow_timeout"
+    WORKFLOW_CANCELED = "workflow_canceled"
+    WORKFLOW_NOT_RUNNABLE = "workflow_not_runnable"
+    HEARTBEAT_TIMEOUT = "heartbeat_timeout"
+    PARENT_CANCELED = "parent_canceled"
+
+
+RUN_ACTIVITY_WORKFLOW = "__run_activity__"
+SLEEP_ACTIVITY_NAME = "__sleep__"
+FINAL_EVENT_POS = 999_999
+SPECIAL_EVENT_POS = 999_998


### PR DESCRIPTION
## Summary
- centralize event types, error codes, and internal names in a constants module
- replace string and numeric literals in engine and worker with new constants

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b494080dfc833092c877f82259fa5b