### PR TITLE
Add database indexes for workflow performance

### DIFF
--- a/django_durable/migrations/0006_add_indexes.py
+++ b/django_durable/migrations/0006_add_indexes.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_durable", "0005_child_workflows"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="workflowexecution",
+            index=models.Index(fields=["status", "updated_at"], name="wf_status_updated_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="workflowexecution",
+            index=models.Index(fields=["status", "expires_at"], name="wf_status_expires_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="historyevent",
+            index=models.Index(fields=["execution", "pos", "type"], name="he_exec_pos_type_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="historyevent",
+            index=models.Index(fields=["execution", "type", "id"], name="he_exec_type_id_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="activitytask",
+            index=models.Index(fields=["status", "expires_at"], name="at_status_expires_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="activitytask",
+            index=models.Index(fields=["status", "heartbeat_timeout"], name="at_status_hb_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="activitytask",
+            index=models.Index(fields=["status", "updated_at"], name="at_status_updated_idx"),
+        ),
+    ]

--- a/django_durable/models.py
+++ b/django_durable/models.py
@@ -33,6 +33,12 @@ class WorkflowExecution(models.Model):
     def __str__(self):
         return f'{self.workflow_name}:{self.id}'
 
+    class Meta:
+        indexes = [
+            models.Index(fields=["status", "updated_at"]),
+            models.Index(fields=["status", "expires_at"]),
+        ]
+
 
 class HistoryEvent(models.Model):
     # Append-only event log; ordered by autoincrement PK
@@ -50,6 +56,8 @@ class HistoryEvent(models.Model):
         indexes = [
             models.Index(fields=['execution', 'pos']),
             models.Index(fields=['execution', 'type']),
+            models.Index(fields=['execution', 'pos', 'type']),
+            models.Index(fields=['execution', 'type', 'id']),
         ]
 
 
@@ -90,4 +98,7 @@ class ActivityTask(models.Model):
         indexes = [
             models.Index(fields=['execution', 'status']),
             models.Index(fields=['status', 'after_time']),
+            models.Index(fields=['status', 'expires_at']),
+            models.Index(fields=['status', 'heartbeat_timeout']),
+            models.Index(fields=['status', 'updated_at']),
         ]


### PR DESCRIPTION
## Summary
- add indexes for workflow status lookups
- index history events by execution, position and type
- index activity task timeout and heartbeat fields

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4992501fc83309a39e02b25d936c3