### PR TITLE
Configure ruff linting, formatting and isort imports

### DIFF
--- a/django_durable/admin.py
+++ b/django_durable/admin.py
@@ -1,14 +1,14 @@
 from django.contrib import admin
 
-from .models import WorkflowExecution, HistoryEvent, ActivityTask
+from .models import ActivityTask, HistoryEvent, WorkflowExecution
 
 
 class HistoryEventInline(admin.TabularInline):
     model = HistoryEvent
     extra = 0
-    fields = ("type", "pos", "created_at", "details")
-    readonly_fields = ("created_at",)
-    ordering = ("id",)
+    fields = ('type', 'pos', 'created_at', 'details')
+    readonly_fields = ('created_at',)
+    ordering = ('id',)
     show_change_link = True
 
 
@@ -16,44 +16,44 @@ class ActivityTaskInline(admin.TabularInline):
     model = ActivityTask
     extra = 0
     fields = (
-        "id",
-        "activity_name",
-        "status",
-        "pos",
-        "after_time",
-        "attempt",
-        "max_attempts",
-        "started_at",
-        "finished_at",
+        'id',
+        'activity_name',
+        'status',
+        'pos',
+        'after_time',
+        'attempt',
+        'max_attempts',
+        'started_at',
+        'finished_at',
     )
-    readonly_fields = ("id", "started_at", "finished_at")
-    ordering = ("-updated_at",)
+    readonly_fields = ('id', 'started_at', 'finished_at')
+    ordering = ('-updated_at',)
     show_change_link = True
 
 
 @admin.register(WorkflowExecution)
 class WorkflowExecutionAdmin(admin.ModelAdmin):
     list_display = (
-        "id",
-        "workflow_name",
-        "status",
-        "started_at",
-        "finished_at",
-        "updated_at",
+        'id',
+        'workflow_name',
+        'status',
+        'started_at',
+        'finished_at',
+        'updated_at',
     )
-    list_filter = ("status", "workflow_name")
-    search_fields = ("id", "workflow_name")
-    date_hierarchy = "started_at"
-    readonly_fields = ("started_at", "finished_at", "updated_at")
+    list_filter = ('status', 'workflow_name')
+    search_fields = ('id', 'workflow_name')
+    date_hierarchy = 'started_at'
+    readonly_fields = ('started_at', 'finished_at', 'updated_at')
     fields = (
-        "workflow_name",
-        "status",
-        "input",
-        "result",
-        "error",
-        "started_at",
-        "finished_at",
-        "updated_at",
+        'workflow_name',
+        'status',
+        'input',
+        'result',
+        'error',
+        'started_at',
+        'finished_at',
+        'updated_at',
     )
     inlines = [ActivityTaskInline, HistoryEventInline]
 
@@ -61,28 +61,27 @@ class WorkflowExecutionAdmin(admin.ModelAdmin):
 @admin.register(ActivityTask)
 class ActivityTaskAdmin(admin.ModelAdmin):
     list_display = (
-        "id",
-        "execution",
-        "activity_name",
-        "status",
-        "pos",
-        "after_time",
-        "attempt",
-        "started_at",
-        "finished_at",
-        "updated_at",
+        'id',
+        'execution',
+        'activity_name',
+        'status',
+        'pos',
+        'after_time',
+        'attempt',
+        'started_at',
+        'finished_at',
+        'updated_at',
     )
-    list_filter = ("status", "activity_name")
-    search_fields = ("id", "execution__id", "activity_name")
-    date_hierarchy = "after_time"
-    readonly_fields = ("started_at", "finished_at", "updated_at")
+    list_filter = ('status', 'activity_name')
+    search_fields = ('id', 'execution__id', 'activity_name')
+    date_hierarchy = 'after_time'
+    readonly_fields = ('started_at', 'finished_at', 'updated_at')
 
 
 @admin.register(HistoryEvent)
 class HistoryEventAdmin(admin.ModelAdmin):
-    list_display = ("id", "execution", "type", "pos", "created_at")
-    list_filter = ("type",)
-    search_fields = ("id", "execution__id", "type")
-    date_hierarchy = "created_at"
-    ordering = ("-id",)
-
+    list_display = ('id', 'execution', 'type', 'pos', 'created_at')
+    list_filter = ('type',)
+    search_fields = ('id', 'execution__id', 'type')
+    date_hierarchy = 'created_at'
+    ordering = ('-id',)

--- a/django_durable/constants.py
+++ b/django_durable/constants.py
@@ -1,35 +1,36 @@
 from enum import Enum
 
+
 class HistoryEventType(str, Enum):
-    VERSION_MARKER = "version_marker"
-    ACTIVITY_SCHEDULED = "activity_scheduled"
-    ACTIVITY_COMPLETED = "activity_completed"
-    ACTIVITY_FAILED = "activity_failed"
-    ACTIVITY_TIMED_OUT = "activity_timed_out"
-    SIGNAL_ENQUEUED = "signal_enqueued"
-    SIGNAL_WAIT = "signal_wait"
-    SIGNAL_CONSUMED = "signal_consumed"
-    CHILD_WORKFLOW_SCHEDULED = "child_workflow_scheduled"
-    CHILD_WORKFLOW_COMPLETED = "child_workflow_completed"
-    CHILD_WORKFLOW_FAILED = "child_workflow_failed"
-    WORKFLOW_STARTED = "workflow_started"
-    WORKFLOW_COMPLETED = "workflow_completed"
-    WORKFLOW_FAILED = "workflow_failed"
-    WORKFLOW_CANCELED = "workflow_canceled"
-    WORKFLOW_TIMED_OUT = "workflow_timed_out"
+    VERSION_MARKER = 'version_marker'
+    ACTIVITY_SCHEDULED = 'activity_scheduled'
+    ACTIVITY_COMPLETED = 'activity_completed'
+    ACTIVITY_FAILED = 'activity_failed'
+    ACTIVITY_TIMED_OUT = 'activity_timed_out'
+    SIGNAL_ENQUEUED = 'signal_enqueued'
+    SIGNAL_WAIT = 'signal_wait'
+    SIGNAL_CONSUMED = 'signal_consumed'
+    CHILD_WORKFLOW_SCHEDULED = 'child_workflow_scheduled'
+    CHILD_WORKFLOW_COMPLETED = 'child_workflow_completed'
+    CHILD_WORKFLOW_FAILED = 'child_workflow_failed'
+    WORKFLOW_STARTED = 'workflow_started'
+    WORKFLOW_COMPLETED = 'workflow_completed'
+    WORKFLOW_FAILED = 'workflow_failed'
+    WORKFLOW_CANCELED = 'workflow_canceled'
+    WORKFLOW_TIMED_OUT = 'workflow_timed_out'
 
 
 class ErrorCode(str, Enum):
-    ACTIVITY_FAILED = "activity_failed"
-    ACTIVITY_TIMEOUT = "activity_timeout"
-    WORKFLOW_TIMEOUT = "workflow_timeout"
-    WORKFLOW_CANCELED = "workflow_canceled"
-    WORKFLOW_NOT_RUNNABLE = "workflow_not_runnable"
-    HEARTBEAT_TIMEOUT = "heartbeat_timeout"
-    PARENT_CANCELED = "parent_canceled"
+    ACTIVITY_FAILED = 'activity_failed'
+    ACTIVITY_TIMEOUT = 'activity_timeout'
+    WORKFLOW_TIMEOUT = 'workflow_timeout'
+    WORKFLOW_CANCELED = 'workflow_canceled'
+    WORKFLOW_NOT_RUNNABLE = 'workflow_not_runnable'
+    HEARTBEAT_TIMEOUT = 'heartbeat_timeout'
+    PARENT_CANCELED = 'parent_canceled'
 
 
-RUN_ACTIVITY_WORKFLOW = "__run_activity__"
-SLEEP_ACTIVITY_NAME = "__sleep__"
+RUN_ACTIVITY_WORKFLOW = '__run_activity__'
+SLEEP_ACTIVITY_NAME = '__sleep__'
 FINAL_EVENT_POS = 999_999
 SPECIAL_EVENT_POS = 999_998

--- a/django_durable/management/commands/durable_cancel.py
+++ b/django_durable/management/commands/durable_cancel.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from django_durable.models import WorkflowExecution
 from django_durable.engine import cancel_workflow
+from django_durable.models import WorkflowExecution
 
 
 class Command(BaseCommand):
@@ -28,4 +28,3 @@ class Command(BaseCommand):
 
         cancel_workflow(wf, reason=reason, cancel_queued_activities=not keep)
         self.stdout.write(self.style.SUCCESS('CANCELED'))
-

--- a/django_durable/management/commands/durable_signal.py
+++ b/django_durable/management/commands/durable_signal.py
@@ -1,9 +1,9 @@
 import json
-from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
 
-from django_durable.models import WorkflowExecution
+from django.core.management.base import BaseCommand, CommandError
+
 from django_durable.engine import send_signal
+from django_durable.models import WorkflowExecution
 
 
 class Command(BaseCommand):
@@ -33,4 +33,3 @@ class Command(BaseCommand):
 
         send_signal(wf, name, payload)
         self.stdout.write(self.style.SUCCESS('OK'))
-

--- a/django_durable/management/commands/durable_start.py
+++ b/django_durable/management/commands/durable_start.py
@@ -1,7 +1,9 @@
 import json
 from datetime import timedelta
+
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
+
 from django_durable.models import WorkflowExecution
 from django_durable.registry import register
 

--- a/django_durable/management/commands/durable_status.py
+++ b/django_durable/management/commands/durable_status.py
@@ -1,8 +1,9 @@
 import json
+
 from django.core.management.base import BaseCommand, CommandError
 
-from django_durable.models import WorkflowExecution
 from django_durable.engine import query_workflow
+from django_durable.models import WorkflowExecution
 
 
 class Command(BaseCommand):
@@ -38,4 +39,3 @@ class Command(BaseCommand):
             raise CommandError(str(e))
 
         self.stdout.write(json.dumps(res))
-

--- a/django_durable/models.py
+++ b/django_durable/models.py
@@ -1,4 +1,5 @@
 import uuid
+
 from django.db import models
 from django.utils import timezone
 
@@ -35,8 +36,8 @@ class WorkflowExecution(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=["status", "updated_at"]),
-            models.Index(fields=["status", "expires_at"]),
+            models.Index(fields=['status', 'updated_at']),
+            models.Index(fields=['status', 'expires_at']),
         ]
 
 

--- a/django_durable/registry.py
+++ b/django_durable/registry.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from typing import Callable, Dict, List, Optional
 
 
@@ -33,7 +33,7 @@ class Register:
         max_retries: int = 0,
         timeout: Optional[float] = None,
         heartbeat_timeout: Optional[float] = None,
-        retry_policy: Optional["RetryPolicy"] = None,
+        retry_policy: Optional['RetryPolicy'] = None,
     ):
         def deco(fn):
             if retry_policy is None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,28 @@
+"""Nox sessions for testing and linting."""
+
+import nox
+
+nox.options.sessions = ('lint', 'tests')
+
+
+@nox.session(venv_backend='uv')
+def lint(session: nox.Session) -> None:
+    """Run static analysis."""
+    session.install('ruff', 'isort')
+    session.run('ruff', 'check', '.')
+    session.run('isort', '--check-only', '.')
+
+
+@nox.session(venv_backend='uv')
+def format(session: nox.Session) -> None:
+    """Format the code."""
+    session.install('ruff', 'isort')
+    session.run('ruff', 'format', '.')
+    session.run('isort', '.')
+
+
+@nox.session(venv_backend='uv')
+def tests(session: nox.Session) -> None:
+    """Run the test suite."""
+    session.install('pytest')
+    session.run('pytest')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest~=8.2",
+    "ruff~=0.4",
+    "isort~=5.13",
+    "nox>=2024.4.15",
 ]
 
 [tool.setuptools]
@@ -23,4 +26,20 @@ build-backend = "setuptools.build_meta"
 [tool.uv]
 dev-dependencies = [
     "pytest~=8.2",
+    "ruff~=0.4",
+    "isort~=5.13",
+    "nox>=2024.4.15",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py313"
+extend-exclude = ["testproj", "django_durable/migrations", "manage.py"]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.isort]
+profile = "black"
+line_length = 88
+skip = ["testproj", "django_durable/migrations", "manage.py", ".venv"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,15 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
+
+[[package]]
+name = "argcomplete"
+version = "3.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/0f/861e168fc813c56a78b35f3c30d91c6757d1fd185af1110f1aec784b35d0/argcomplete-3.6.2.tar.gz", hash = "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf", size = 73403, upload-time = "2025-04-03T04:57:03.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/da/e42d7a9d8dd33fa775f467e4028a47936da2f01e4b0e561f9ba0d74cb0ca/argcomplete-3.6.2-py3-none-any.whl", hash = "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591", size = 43708, upload-time = "2025-04-03T04:57:01.591Z" },
+]
 
 [[package]]
 name = "asgiref"
@@ -12,12 +21,54 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/7a/359f4d5df2353f26172b3cc39ea32daa39af8de522205f512f458923e677/colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2", size = 16624, upload-time = "2024-10-29T18:34:51.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/51/9b208e85196941db2f0654ad0357ca6388ab3ed67efdbfc799f35d1f83aa/colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff", size = 11424, upload-time = "2024-10-29T18:34:49.815Z" },
+]
+
+[[package]]
+name = "dependency-groups"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz", hash = "sha256:78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd", size = 10093, upload-time = "2025-05-02T00:34:29.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/c7/d1ec24fb280caa5a79b6b950db565dab30210a66259d17d5bb2b3a9f878d/dependency_groups-1.3.1-py3-none-any.whl", hash = "sha256:51aeaa0dfad72430fcfb7bcdbefbd75f3792e5919563077f30bc0d73f4493030", size = 8664, upload-time = "2025-05-02T00:34:27.085Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -44,15 +95,46 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "isort" },
+    { name = "nox" },
     { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "isort" },
+    { name = "nox" },
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "django" },
+    { name = "isort", marker = "extra == 'dev'", specifier = "~=5.13" },
+    { name = "nox", marker = "extra == 'dev'", specifier = ">=2024.4.15" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "~=8.2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.4" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "isort", specifier = "~=5.13" },
+    { name = "nox", specifier = ">=2024.4.15" },
+    { name = "pytest", specifier = "~=8.2" },
+    { name = "ruff", specifier = "~=0.4" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -64,12 +146,47 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "5.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
+]
+
+[[package]]
+name = "nox"
+version = "2025.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "attrs" },
+    { name = "colorlog" },
+    { name = "dependency-groups" },
+    { name = "packaging" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/80/47712208c410defec169992e57c179f0f4d92f5dd17ba8daca50a8077e23/nox-2025.5.1.tar.gz", hash = "sha256:2a571dfa7a58acc726521ac3cd8184455ebcdcbf26401c7b737b5bc6701427b2", size = 4023334, upload-time = "2025-05-01T16:35:48.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/be/7b423b02b09eb856beffe76fe8c4121c99852db74dd12a422dcb72d1134e/nox-2025.5.1-py3-none-any.whl", hash = "sha256:56abd55cf37ff523c254fcec4d152ed51e5fe80e2ab8317221d8b828ac970a31", size = 71753, upload-time = "2025-05-01T16:35:46.037Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
 ]
 
 [[package]]
@@ -107,6 +224,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.12.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/55/16ab6a7d88d93001e1ae4c34cbdcfb376652d761799459ff27c1dc20f6fa/ruff-0.12.11.tar.gz", hash = "sha256:c6b09ae8426a65bbee5425b9d0b82796dbb07cb1af045743c79bfb163001165d", size = 5347103, upload-time = "2025-08-28T13:59:08.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/a2/3b3573e474de39a7a475f3fbaf36a25600bfeb238e1a90392799163b64a0/ruff-0.12.11-py3-none-linux_armv6l.whl", hash = "sha256:93fce71e1cac3a8bf9200e63a38ac5c078f3b6baebffb74ba5274fb2ab276065", size = 11979885, upload-time = "2025-08-28T13:58:26.654Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e4/235ad6d1785a2012d3ded2350fd9bc5c5af8c6f56820e696b0118dfe7d24/ruff-0.12.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b8e33ac7b28c772440afa80cebb972ffd823621ded90404f29e5ab6d1e2d4b93", size = 12742364, upload-time = "2025-08-28T13:58:30.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0d/15b72c5fe6b1e402a543aa9d8960e0a7e19dfb079f5b0b424db48b7febab/ruff-0.12.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d69fb9d4937aa19adb2e9f058bc4fbfe986c2040acb1a4a9747734834eaa0bfd", size = 11920111, upload-time = "2025-08-28T13:58:33.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/f66339d7893798ad3e17fa5a1e587d6fd9806f7c1c062b63f8b09dda6702/ruff-0.12.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:411954eca8464595077a93e580e2918d0a01a19317af0a72132283e28ae21bee", size = 12160060, upload-time = "2025-08-28T13:58:35.74Z" },
+    { url = "https://files.pythonhosted.org/packages/03/69/9870368326db26f20c946205fb2d0008988aea552dbaec35fbacbb46efaa/ruff-0.12.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a2c0a2e1a450f387bf2c6237c727dd22191ae8c00e448e0672d624b2bbd7fb0", size = 11799848, upload-time = "2025-08-28T13:58:38.051Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/dd2c7f990e9b3a8a55eee09d4e675027d31727ce33cdb29eab32d025bdc9/ruff-0.12.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ca4c3a7f937725fd2413c0e884b5248a19369ab9bdd850b5781348ba283f644", size = 13536288, upload-time = "2025-08-28T13:58:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/30/d5496fa09aba59b5e01ea76775a4c8897b13055884f56f1c35a4194c2297/ruff-0.12.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4d1df0098124006f6a66ecf3581a7f7e754c4df7644b2e6704cd7ca80ff95211", size = 14490633, upload-time = "2025-08-28T13:58:42.285Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2f/81f998180ad53445d403c386549d6946d0748e536d58fce5b5e173511183/ruff-0.12.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a8dd5f230efc99a24ace3b77e3555d3fbc0343aeed3fc84c8d89e75ab2ff793", size = 13888430, upload-time = "2025-08-28T13:58:44.641Z" },
+    { url = "https://files.pythonhosted.org/packages/87/71/23a0d1d5892a377478c61dbbcffe82a3476b050f38b5162171942a029ef3/ruff-0.12.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dc75533039d0ed04cd33fb8ca9ac9620b99672fe7ff1533b6402206901c34ee", size = 12913133, upload-time = "2025-08-28T13:58:47.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/22/3c6cef96627f89b344c933781ed38329bfb87737aa438f15da95907cbfd5/ruff-0.12.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fc58f9266d62c6eccc75261a665f26b4ef64840887fc6cbc552ce5b29f96cc8", size = 13169082, upload-time = "2025-08-28T13:58:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b5/68b3ff96160d8b49e8dd10785ff3186be18fd650d356036a3770386e6c7f/ruff-0.12.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5a0113bd6eafd545146440225fe60b4e9489f59eb5f5f107acd715ba5f0b3d2f", size = 13139490, upload-time = "2025-08-28T13:58:51.593Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b9/050a3278ecd558f74f7ee016fbdf10591d50119df8d5f5da45a22c6afafc/ruff-0.12.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0d737b4059d66295c3ea5720e6efc152623bb83fde5444209b69cd33a53e2000", size = 11958928, upload-time = "2025-08-28T13:58:53.943Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bc/93be37347db854806904a43b0493af8d6873472dfb4b4b8cbb27786eb651/ruff-0.12.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:916fc5defee32dbc1fc1650b576a8fed68f5e8256e2180d4d9855aea43d6aab2", size = 11764513, upload-time = "2025-08-28T13:58:55.976Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/1471751e2015a81fd8e166cd311456c11df74c7e8769d4aabfbc7584c7ac/ruff-0.12.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c984f07d7adb42d3ded5be894fb4007f30f82c87559438b4879fe7aa08c62b39", size = 12745154, upload-time = "2025-08-28T13:58:58.16Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/2542b14890d0f4872dd81b7b2a6aed3ac1786fae1ce9b17e11e6df9e31e3/ruff-0.12.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e07fbb89f2e9249f219d88331c833860489b49cdf4b032b8e4432e9b13e8a4b9", size = 13227653, upload-time = "2025-08-28T13:59:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/2fbfc61047dbfd009c58a28369a693a1484ad15441723be1cd7fe69bb679/ruff-0.12.11-py3-none-win32.whl", hash = "sha256:c792e8f597c9c756e9bcd4d87cf407a00b60af77078c96f7b6366ea2ce9ba9d3", size = 11944270, upload-time = "2025-08-28T13:59:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/34276984705bfe069cd383101c45077ee029c3fe3b28225bf67aa35f0647/ruff-0.12.11-py3-none-win_amd64.whl", hash = "sha256:a3283325960307915b6deb3576b96919ee89432ebd9c48771ca12ee8afe4a0fd", size = 13046600, upload-time = "2025-08-28T13:59:04.751Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a8/001d4a7c2b37623a3fd7463208267fb906df40ff31db496157549cfd6e72/ruff-0.12.11-py3-none-win_arm64.whl", hash = "sha256:bae4d6e6a2676f8fb0f98b74594a048bae1b944aab17e9f5d504062303c6dbea", size = 12135290, upload-time = "2025-08-28T13:59:06.933Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -122,4 +265,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
 ]


### PR DESCRIPTION
## Summary
- add ruff, isort and nox dev tools
- configure ruff lint/format and isort rules in `pyproject.toml`
- provide nox sessions for linting, formatting and tests
- use single quotes in ruff formatting

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run isort --check-only .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d280e36c8330b7f92fe3528bdfd7