### PR TITLE
Refactor workflow/activity APIs

### DIFF
--- a/django_durable/__init__.py
+++ b/django_durable/__init__.py
@@ -1,1 +1,18 @@
+__all__ = [
+    "start_workflow",
+    "wait_workflow",
+    "run_workflow",
+    "send_signal",
+    "query_workflow",
+]
+
+
+def __getattr__(name):
+    if name in __all__:
+        from . import api as _api
+
+        return getattr(_api, name)
+    raise AttributeError(name)
+
+
 default_app_config = 'django_durable.apps.DjangoDurableConfig'

--- a/django_durable/api.py
+++ b/django_durable/api.py
@@ -1,0 +1,30 @@
+from typing import Any, Optional, Union
+
+from .engine import (
+    _run_workflow,
+    _start_workflow,
+    _wait_workflow,
+    query_workflow,
+    send_signal,
+)
+from .models import WorkflowExecution
+
+__all__ = [
+    "start_workflow",
+    "wait_workflow",
+    "run_workflow",
+    "send_signal",
+    "query_workflow",
+]
+
+def start_workflow(workflow_name: str, timeout: Optional[float] = None, **inputs) -> str:
+    """Create a workflow execution and return its handle (ID)."""
+    return _start_workflow(workflow_name, timeout=timeout, **inputs)
+
+def wait_workflow(execution: Union[WorkflowExecution, str]) -> Any:
+    """Wait for a workflow execution to complete and return its result."""
+    return _wait_workflow(execution)
+
+def run_workflow(workflow_name: str, timeout: Optional[float] = None, **inputs) -> Any:
+    """Convenience helper: start a workflow and wait for its result."""
+    return _run_workflow(workflow_name, timeout=timeout, **inputs)

--- a/django_durable/constants.py
+++ b/django_durable/constants.py
@@ -30,7 +30,6 @@ class ErrorCode(str, Enum):
     PARENT_CANCELED = 'parent_canceled'
 
 
-RUN_ACTIVITY_WORKFLOW = '__run_activity__'
 SLEEP_ACTIVITY_NAME = '__sleep__'
 FINAL_EVENT_POS = 999_999
 SPECIAL_EVENT_POS = 999_998

--- a/django_durable/management/commands/durable_worker.py
+++ b/django_durable/management/commands/durable_worker.py
@@ -1,6 +1,7 @@
 import socket
 import time
-from datetime import timedelta, timedelta as _td
+from datetime import timedelta
+from datetime import timedelta as _td
 
 from django.core.management.base import BaseCommand
 from django.db import DatabaseError

--- a/testproj/benchmark.py
+++ b/testproj/benchmark.py
@@ -1,8 +1,8 @@
-import os
-import time
-import multiprocessing
-import sys
 import argparse
+import multiprocessing
+import os
+import sys
+import time
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproj.settings")
 
@@ -13,7 +13,8 @@ django.setup()
 
 from django.core.management import call_command
 from django.db import connection
-from django_durable.engine import start_activity, start_workflow
+
+from django_durable import start_workflow
 from django_durable.models import ActivityTask, WorkflowExecution
 
 WORKERS = 10
@@ -64,12 +65,6 @@ def _run_benchmark(start_fn, count):
         p.terminate()
         p.join()
     return count / elapsed
-
-
-def benchmark_activities(count=TASKS):
-    return _run_benchmark(lambda: start_activity("add", 1, 1), count)
-
-
 def benchmark_workflows(count=TASKS):
     return _run_benchmark(lambda: start_workflow("add_flow", a=1, b=1), count)
 
@@ -79,7 +74,5 @@ if __name__ == "__main__":
     parser.add_argument("--tasks", type=int, default=TASKS, help="Number of tasks per benchmark")
     args = parser.parse_args()
     call_command("migrate", verbosity=0, interactive=False)
-    act_rate = benchmark_activities(args.tasks)
     wf_rate = benchmark_workflows(args.tasks)
-    print(f"Activities per second: {act_rate:.2f}")
     print(f"Workflows per second: {wf_rate:.2f}")


### PR DESCRIPTION
## Summary
- add context-level start/wait/run for activities and workflows
- expose workflow start/wait/run via new `api` module
- update tests and benchmark to use public API

## Testing
- `nox -s lint`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68b4eaf19cec83308c35e91013ed921f