### PR TITLE
Remove deprecated activity/workflow context aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Durable execution framework for Django web apps.
 
-Workflows are ordinary Python functions using `ctx.activity()` and `ctx.sleep()`. On each step, we replay from the start and use the **event log** (`HistoryEvent`) to return prior results. Avoid non-deterministic branching not derived from previous results or inputs.
+Workflows are ordinary Python functions using `ctx.run_activity()` and `ctx.sleep()`. On each step, we replay from the start and use the **event log** (`HistoryEvent`) to return prior results. Avoid non-deterministic branching not derived from previous results or inputs.
 
 Activity and workflow results must be JSON-serializable.
 

--- a/django_durable/engine.py
+++ b/django_durable/engine.py
@@ -186,13 +186,9 @@ class Context:
         handle = self.start_activity(name, *args, **kwargs)
         return self.wait_activity(handle)
 
-    def activity(self, name: str, *args, **kwargs) -> Any:
-        """Alias for ``run_activity`` for backward compatibility."""
-        return self.run_activity(name, *args, **kwargs)
-
     def sleep(self, seconds: float):
         """Durable timer implemented as a special internal activity."""
-        return self.activity(SLEEP_ACTIVITY_NAME, seconds)
+        return self.run_activity(SLEEP_ACTIVITY_NAME, seconds)
 
     def wait_signal(self, name: str) -> Any:
         """Deterministic wait for an external signal.
@@ -355,10 +351,6 @@ class Context:
     def run_workflow(self, name: str, timeout: Optional[float] = None, **input) -> Any:
         handle = self.start_workflow(name, timeout=timeout, **input)
         return self.wait_workflow(handle)
-
-    def workflow(self, name: str, timeout: Optional[float] = None, **input) -> Any:
-        """Alias for ``run_workflow`` for backward compatibility."""
-        return self.run_workflow(name, timeout=timeout, **input)
 
 
 def _run_workflow_once(exec_obj: WorkflowExecution) -> Optional[Any]:

--- a/testproj/durable_workflows.py
+++ b/testproj/durable_workflows.py
@@ -5,25 +5,25 @@ from django_durable.registry import register
 @register.workflow()
 def onboard_user(ctx, user_id: int):
     # 1) send email (schedules ActivityTask, then pauses; worker resumes deterministically)
-    res = ctx.activity("send_welcome_email", user_id)
+    res = ctx.run_activity("send_welcome_email", user_id)
     # 2) wait 1 hour without blocking a worker thread
     ctx.sleep(3600)
     # 3) check confirmation
-    clicked = ctx.activity("confirm_clicked", user_id)
+    clicked = ctx.run_activity("confirm_clicked", user_id)
     if not clicked["clicked"]:
         # try again in a day
         ctx.sleep(24 * 3600)
-        ctx.activity("send_welcome_email", user_id)
+        ctx.run_activity("send_welcome_email", user_id)
 
     # 4) compute score and finish
-    score = ctx.activity("compute_score", user_id)
+    score = ctx.run_activity("compute_score", user_id)
     return {"ok": True, "score": score["score"]}
 
 
 @register.workflow()
 def e2e_flow(ctx, value):
     # activity
-    res = ctx.activity("echo", value)
+    res = ctx.run_activity("echo", value)
     # immediate timer
     ctx.sleep(0)
     # wait for external signal 'go'
@@ -40,13 +40,13 @@ def history(execution):
 @register.workflow()
 def complex_flow(ctx, value):
     # chain multiple activities with timers and a signal
-    first = ctx.activity("add", value, 5)
+    first = ctx.run_activity("add", value, 5)
     ctx.sleep(0)
-    second = ctx.activity("multiply", first["value"], 2)
+    second = ctx.run_activity("multiply", first["value"], 2)
     ctx.sleep(0)
     sig = ctx.wait_signal("finish")
     ctx.sleep(0)
-    final = ctx.activity("add", second["value"], sig["add"])
+    final = ctx.run_activity("add", second["value"], sig["add"])
     return {"result": final["value"], "sig": sig}
 
 
@@ -55,48 +55,48 @@ def sleep_work_loop(ctx, loops: int, sleep: float):
     """Workflow that alternates between sleeping and doing trivial work."""
     for i in range(loops):
         ctx.sleep(sleep)
-        ctx.activity("do_work", i)
+        ctx.run_activity("do_work", i)
     return {"done": loops}
 
 
 @register.workflow()
 def activity_timeout_flow(ctx):
-    ctx.activity("echo", "hi", schedule_to_close_timeout=0)
+    ctx.run_activity("echo", "hi", schedule_to_close_timeout=0)
 
 
 @register.workflow()
 def retry_flow(ctx, key: str, fail_times: int):
-    res = ctx.activity("flaky", key, fail_times)
+    res = ctx.run_activity("flaky", key, fail_times)
     return {"attempts": res["attempts"]}
 
 
 @register.workflow()
 def heartbeat_flow(ctx):
-    res = ctx.activity("heartbeat_activity")
+    res = ctx.run_activity("heartbeat_activity")
     return res
 
 
 @register.workflow()
 def heartbeat_timeout_flow(ctx):
-    ctx.activity("no_heartbeat_activity")
+    ctx.run_activity("no_heartbeat_activity")
 
 
 @register.workflow()
 def add_flow(ctx, a: int, b: int):
     """Simple workflow used for benchmarks."""
-    res = ctx.activity("add", a, b)
+    res = ctx.run_activity("add", a, b)
     return {"value": res["value"]}
 
 
 @register.workflow()
 def child_increment_workflow(ctx, x: int):
-    res = ctx.activity("add", x, 1)
+    res = ctx.run_activity("add", x, 1)
     return {"y": res["value"]}
 
 
 @register.workflow()
 def parent_child_workflow(ctx, x: int):
-    child = ctx.workflow("child_increment_workflow", x=x)
+    child = ctx.run_workflow("child_increment_workflow", x=x)
     return {"child": child}
 
 @register.workflow()
@@ -104,7 +104,7 @@ def long_running_step_flow(ctx, loops: int, delay: float):
     """Workflow with long-running steps to test recovery when worker dies mid-execution."""
     for i in range(loops):
         time.sleep(delay)
-        ctx.activity("do_work", i)
+        ctx.run_activity("do_work", i)
     return {"done": loops}
 
 
@@ -112,5 +112,5 @@ def long_running_step_flow(ctx, loops: int, delay: float):
 def long_activity_flow(ctx, loops: int, delay: float):
     """Workflow with slow activities to test recovery when worker dies during an activity."""
     for _ in range(loops):
-        ctx.activity("slow_sleep", delay)
+        ctx.run_activity("slow_sleep", delay)
     return {"done": loops}

--- a/testproj/tests/test_sync_api.py
+++ b/testproj/tests/test_sync_api.py
@@ -45,7 +45,7 @@ def test_start_and_wait_workflow():
 def test_activity_within_workflow():
     @register.workflow()
     def add_flow(ctx, a, b):
-        return ctx.activity("add", a, b)
+        return ctx.run_activity("add", a, b)
 
     res = run_workflow("add_flow", a=3, b=4)
     assert res == {"value": 7}
@@ -69,7 +69,7 @@ def test_run_workflow_with_child_workflow():
 
     @register.workflow()
     def parent(ctx, x):
-        return {"child": ctx.workflow("child", x=x)}
+        return {"child": ctx.run_workflow("child", x=x)}
 
     res = run_workflow("parent", x=3)
     assert res == {"child": {"res": 4}}
@@ -82,7 +82,7 @@ def test_child_workflow_failure_propagates():
 
     @register.workflow()
     def parent(ctx):
-        ctx.workflow("failing_child")
+        ctx.run_workflow("failing_child")
 
     with pytest.raises(RuntimeError):
         run_workflow("parent")

--- a/testproj/tests/test_versioning.py
+++ b/testproj/tests/test_versioning.py
@@ -41,9 +41,9 @@ def test_get_version_survives_code_change():
     def version_flow(ctx):
         v = ctx.get_version("change", 1)
         if v == 1:
-            res = ctx.activity("echo", "v1")
+            res = ctx.run_activity("echo", "v1")
         else:
-            res = ctx.activity("echo", "v2")
+            res = ctx.run_activity("echo", "v2")
         ctx.wait_signal("go")
         return res["value"]
 
@@ -56,9 +56,9 @@ def test_get_version_survives_code_change():
     def version_flow(ctx):
         v = ctx.get_version("change", 2)
         if v == 1:
-            res = ctx.activity("echo", "v1")
+            res = ctx.run_activity("echo", "v1")
         else:
-            res = ctx.activity("echo", "v2")
+            res = ctx.run_activity("echo", "v2")
         sig = ctx.wait_signal("go")
         return res["value"]
 
@@ -81,9 +81,9 @@ def test_patch_deprecation_allows_removal():
     @register.workflow(name="patch_flow")
     def patch_flow(ctx):
         if ctx.patched("feat"):
-            res = ctx.activity("echo", "new")
+            res = ctx.run_activity("echo", "new")
         else:
-            res = ctx.activity("echo", "old")
+            res = ctx.run_activity("echo", "old")
         ctx.wait_signal("go")
         return res["value"]
 
@@ -95,7 +95,7 @@ def test_patch_deprecation_allows_removal():
     @register.workflow(name="patch_flow")
     def patch_flow(ctx):
         ctx.deprecate_patch("feat")
-        res = ctx.activity("echo", "new")
+        res = ctx.run_activity("echo", "new")
         ctx.wait_signal("go")
         return res["value"]
 


### PR DESCRIPTION
## Summary
- remove backward-compatibility `activity` and `workflow` helpers from workflow context
- update docs, example workflows and tests to use `ctx.run_activity`/`ctx.run_workflow`

## Testing
- `nox -s lint`
- `nox -s tests` *(fails: sqlite3.OperationalError: database is locked)*
- `nox -s docs`


------
https://chatgpt.com/codex/tasks/task_e_68b5cbf4f350833082a10696a10445fd