### PR TITLE
Add system check for nondeterministic workflows

### DIFF
--- a/django_durable/apps.py
+++ b/django_durable/apps.py
@@ -10,3 +10,6 @@ class DjangoDurableConfig(AppConfig):
         # Auto-discover user-defined workflows/activities
         autodiscover_modules('durable_workflows')
         autodiscover_modules('durable_activities')
+
+        # Register system checks
+        from . import checks  # noqa: F401

--- a/django_durable/checks.py
+++ b/django_durable/checks.py
@@ -1,0 +1,82 @@
+import ast
+import inspect
+import textwrap
+from typing import List
+
+from django.core import checks
+
+from .registry import register
+
+# Modules that are generally non-deterministic and should not be used in workflows
+NON_DETERMINISTIC_MODULES = {
+    "random",
+    "secrets",
+    "uuid",
+    "requests",
+    "httpx",
+    "urllib",
+    "urllib3",
+}
+
+# Fully-qualified function calls that are obviously non-deterministic
+NON_DETERMINISTIC_CALLS = {
+    "time.time",
+    "datetime.datetime.now",
+    "datetime.datetime.utcnow",
+}
+
+
+def _full_name(node: ast.AST) -> str:
+    """Return a dotted path for an AST node representing a name or attribute."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_full_name(node.value)}.{node.attr}"
+    return ""
+
+
+@checks.register()
+def check_workflow_determinism(app_configs, **kwargs):
+    errors: List[checks.CheckMessage] = []
+
+    for name, fn in register.workflows.items():
+        try:
+            source = textwrap.dedent(inspect.getsource(fn))
+        except (OSError, TypeError):
+            # Can't retrieve source code; skip
+            continue
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    if top in NON_DETERMINISTIC_MODULES:
+                        errors.append(
+                            checks.Warning(
+                                f"Workflow '{name}' imports non-deterministic module '{alias.name}'",
+                                id="django_durable.W001",
+                            )
+                        )
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    top = node.module.split(".")[0]
+                    if top in NON_DETERMINISTIC_MODULES:
+                        errors.append(
+                            checks.Warning(
+                                f"Workflow '{name}' imports non-deterministic module '{node.module}'",
+                                id="django_durable.W001",
+                            )
+                        )
+            elif isinstance(node, ast.Call):
+                full = _full_name(node.func)
+                top = full.split(".")[0]
+                if full in NON_DETERMINISTIC_CALLS or top in NON_DETERMINISTIC_MODULES:
+                    errors.append(
+                        checks.Warning(
+                            f"Workflow '{name}' calls non-deterministic function '{full}'",
+                            id="django_durable.W001",
+                        )
+                    )
+
+    return errors

--- a/testproj/tests/test_checks.py
+++ b/testproj/tests/test_checks.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+
+import django
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproj.settings")
+django.setup()
+
+from django.core.checks import run_checks
+from django_durable.registry import register
+
+
+def test_warns_on_nondeterministic_code():
+    @register.workflow()
+    def random_wf(ctx):
+        import random
+        return random.random()
+
+    errors = run_checks()
+
+    assert any(
+        e.id == "django_durable.W001" and "random" in e.msg for e in errors
+    )
+
+    register.workflows.pop("random_wf", None)


### PR DESCRIPTION
## Summary
- add Django system check that warns when workflows import or call nondeterministic modules/functions (e.g. random, time.time, HTTP clients)
- register the check on app startup
- add regression test verifying that random usage triggers a warning

## Testing
- `ruff check django_durable`
- `pytest`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68b7c4c1e03c83308c58a0c74ff929b3