### PR TITLE
Expose register and rename signal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ python manage.py durable_signal <execution_uuid> user_clicked --input '{"clicked
 You can also send a signal programmatically:
 
 ```python
-from django_durable import send_signal
-send_signal(execution_id, "user_clicked", {"clicked": True})
+from django_durable import signal_workflow
+signal_workflow(execution_id, "user_clicked", {"clicked": True})
 ```
 
 ## Cancellation

--- a/django_durable/__init__.py
+++ b/django_durable/__init__.py
@@ -2,8 +2,9 @@ __all__ = [
     "start_workflow",
     "wait_workflow",
     "run_workflow",
-    "send_signal",
+    "signal_workflow",
     "cancel_workflow",
+    "register",
 ]
 
 

--- a/django_durable/api.py
+++ b/django_durable/api.py
@@ -5,16 +5,18 @@ from .engine import (
     _start_workflow,
     _wait_workflow,
     cancel_workflow,
-    send_signal,
+    signal_workflow,
 )
 from .models import WorkflowExecution
+from .registry import register
 
 __all__ = [
     "start_workflow",
     "wait_workflow",
     "run_workflow",
-    "send_signal",
+    "signal_workflow",
     "cancel_workflow",
+    "register",
 ]
 
 def start_workflow(workflow_name: str, timeout: Optional[float] = None, **inputs) -> str:

--- a/django_durable/engine.py
+++ b/django_durable/engine.py
@@ -651,10 +651,10 @@ def cancel_workflow(
         )
 
 
-def send_signal(
+def signal_workflow(
     execution: Union[WorkflowExecution, str], name: str, payload: Any = None
 ):
-    """Enqueue an external signal for a workflow and mark it runnable.
+    """Signal a workflow by enqueueing an external signal and mark it runnable.
 
     - Appends a 'signal_enqueued' HistoryEvent with the given name/payload.
     - Sets the workflow status to PENDING if it is not terminal.

--- a/django_durable/management/commands/durable_signal.py
+++ b/django_durable/management/commands/durable_signal.py
@@ -2,7 +2,7 @@ import json
 
 from django.core.management.base import BaseCommand, CommandError
 
-from django_durable.engine import send_signal
+from django_durable.engine import signal_workflow
 from django_durable.models import WorkflowExecution
 
 
@@ -31,5 +31,5 @@ class Command(BaseCommand):
         except WorkflowExecution.DoesNotExist:
             raise CommandError(f'WorkflowExecution not found: {exec_id}')
 
-        send_signal(wf, name, payload)
+        signal_workflow(wf, name, payload)
         self.stdout.write(self.style.SUCCESS('OK'))

--- a/django_durable/management/commands/durable_start.py
+++ b/django_durable/management/commands/durable_start.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
 from django_durable.models import WorkflowExecution
-from django_durable.registry import register
+from django_durable import register
 
 
 class Command(BaseCommand):

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ result = wait_workflow(exec_id)
 - Params: `workflow_name: str`, `timeout: float | None = None`, `**inputs`
 - Returns: JSON-serializable result
 
-```{autofunction} django_durable.api.send_signal
+```{autofunction} django_durable.api.signal_workflow
 ```
 
 - Summary: Enqueue an external signal for a workflow and mark it runnable.
@@ -50,8 +50,8 @@ result = wait_workflow(exec_id)
 - Example:
 
 ```python
-from django_durable import send_signal
-send_signal(exec_id, "go", {"clicked": True})
+from django_durable import signal_workflow
+signal_workflow(exec_id, "go", {"clicked": True})
 ```
 
 ```{autofunction} django_durable.api.cancel_workflow
@@ -70,7 +70,7 @@ cancel_workflow(exec_id, reason="user requested")
 
 ## Registry and Decorators
 
-The registry provides decorators to declare workflows and activities. Import from `django_durable.registry`.
+The registry provides decorators to declare workflows and activities. Import from `django_durable`.
 
 - `register.workflow(timeout: float | None = None)`
   - Registers a workflow function. The function signature is `fn(ctx, **inputs)` and must be deterministic relative to inputs and prior results.
@@ -78,7 +78,7 @@ The registry provides decorators to declare workflows and activities. Import fro
   - Optional `timeout` sets a deadline for the workflow; when exceeded, the workflow times out and children are canceled.
   - Example:
     ```python
-    from django_durable.registry import register
+    from django_durable import register
 
     @register.workflow(timeout=3600)
     def add_flow(ctx, a: int, b: int):
@@ -92,7 +92,7 @@ The registry provides decorators to declare workflows and activities. Import fro
   - Timeouts: `timeout` sets schedule-to-close deadline; `heartbeat_timeout` enforces activity heartbeats.
   - Example:
     ```python
-    from django_durable.registry import register
+    from django_durable import register
     from django_durable.retry import RetryPolicy
 
     @register.activity(

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Define activities and a workflow in your Django app (auto-discovered from `durab
 
 ```python
 # myapp/durable_activities.py
-from django_durable.registry import register
+from django_durable import register
 
 @register.activity()
 def send_email(user_id: int):
@@ -25,7 +25,7 @@ def compute_score(user_id: int):
 
 ```python
 # myapp/durable_workflows.py
-from django_durable.registry import register
+from django_durable import register
 
 @register.workflow()
 def onboard_user(ctx, user_id: int):

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -33,7 +33,7 @@ python manage.py createsuperuser  # optional, for admin
 
 ```python
 # yourapp/durable_activities.py
-from django_durable.registry import register
+from django_durable import register
 
 @register.activity()
 def send_welcome_email(user_id: int):
@@ -47,7 +47,7 @@ def compute_score(user_id: int):
 
 ```python
 # yourapp/durable_workflows.py
-from django_durable.registry import register
+from django_durable import register
 
 @register.workflow()
 def onboard_user(ctx, user_id: int):
@@ -127,8 +127,8 @@ python manage.py durable_signal <execution_uuid> go --input '{"clicked": true}'
 ```
 
 ```python
-from django_durable import send_signal
-send_signal(exec_id, "go", {"clicked": True})
+from django_durable import signal_workflow
+signal_workflow(exec_id, "go", {"clicked": True})
 ```
 
 ## 6) Prove Durability

--- a/testproj/benchmark.py
+++ b/testproj/benchmark.py
@@ -110,7 +110,7 @@ def main() -> None:
 
     django.setup()
 
-    from django_durable.registry import register
+    from django_durable import register
 
     @register.activity()
     def bench_activity(payload: str) -> dict:

--- a/testproj/durable_activities.py
+++ b/testproj/durable_activities.py
@@ -1,4 +1,4 @@
-from django_durable.registry import register
+from django_durable import register
 from django_durable.retry import RetryPolicy
 from django_durable.engine import activity_heartbeat
 from time import sleep

--- a/testproj/durable_workflows.py
+++ b/testproj/durable_workflows.py
@@ -1,6 +1,6 @@
 import time
 
-from django_durable.registry import register
+from django_durable import register
 
 @register.workflow()
 def onboard_user(ctx, user_id: int):

--- a/testproj/tests/test_checks.py
+++ b/testproj/tests/test_checks.py
@@ -10,7 +10,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproj.settings")
 django.setup()
 
 from django.core.checks import run_checks
-from django_durable.registry import register
+from django_durable import register
 
 
 def test_warns_on_nondeterministic_code():

--- a/testproj/tests/test_sync_api.py
+++ b/testproj/tests/test_sync_api.py
@@ -16,11 +16,11 @@ from django.core.management import call_command
 from django_durable import (
     cancel_workflow,
     run_workflow,
-    send_signal,
+    signal_workflow,
     start_workflow,
     wait_workflow,
+    register,
 )
-from django_durable.registry import register
 from django_durable.exceptions import (
     ActivityTimeout,
     NondeterminismError,
@@ -107,8 +107,8 @@ def test_signal_queue_consumed_in_order():
         return {"signals": [first, second]}
 
     handle = start_workflow("testproj.sig_flow")
-    send_signal(handle, "go", {"n": 1})
-    send_signal(handle, "go", {"n": 2})
+    signal_workflow(handle, "go", {"n": 1})
+    signal_workflow(handle, "go", {"n": 2})
     res = wait_workflow(handle)
     assert res == {"signals": [{"n": 1}, {"n": 2}]}
 

--- a/testproj/tests/test_versioning.py
+++ b/testproj/tests/test_versioning.py
@@ -11,9 +11,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproj.settings")
 django.setup()
 
 from django.core.management import call_command
-from django_durable.registry import register
+from django_durable import engine, register
 from django_durable.models import WorkflowExecution, ActivityTask
-from django_durable import engine
 import testproj.durable_activities  # ensure activities registered
 
 
@@ -62,14 +61,14 @@ def test_get_version_survives_code_change():
         sig = ctx.wait_signal("go")
         return res["value"]
 
-    engine.send_signal(exec1, "go")
+    engine.signal_workflow(exec1, "go")
     engine.step_workflow(exec1)
     exec1.refresh_from_db()
     assert exec1.result == "v1"
 
     exec2 = WorkflowExecution.objects.create(workflow_name="testproj.version_flow", input={})
     _step_to_waiting(exec2)
-    engine.send_signal(exec2, "go")
+    engine.signal_workflow(exec2, "go")
     engine.step_workflow(exec2)
     exec2.refresh_from_db()
     assert exec2.result == "v2"
@@ -99,14 +98,14 @@ def test_patch_deprecation_allows_removal():
         ctx.wait_signal("go")
         return res["value"]
 
-    engine.send_signal(exec1, "go")
+    engine.signal_workflow(exec1, "go")
     engine.step_workflow(exec1)
     exec1.refresh_from_db()
     assert exec1.result == "new"
 
     exec2 = WorkflowExecution.objects.create(workflow_name="testproj.patch_flow", input={})
     _step_to_waiting(exec2)
-    engine.send_signal(exec2, "go")
+    engine.signal_workflow(exec2, "go")
     engine.step_workflow(exec2)
     exec2.refresh_from_db()
     assert exec2.result == "new"


### PR DESCRIPTION
## Summary
- expose `register` at the top-level API
- rename `send_signal` to `signal_workflow`

## Testing
- `ruff check .`
- `python manage.py migrate --noinput`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85dad304483309137a383ac2caf95