### PR TITLE
feat(admin): add workflow start signal cancel

### DIFF
--- a/django_durable/admin.py
+++ b/django_durable/admin.py
@@ -1,6 +1,26 @@
+from django import forms
 from django.contrib import admin
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.urls import reverse
 
+from .api import cancel_workflow, signal_workflow, start_workflow
 from .models import ActivityTask, HistoryEvent, WorkflowExecution
+
+
+class StartWorkflowForm(forms.Form):
+    workflow_name = forms.CharField(label="Workflow name")
+    params = forms.JSONField(
+        required=False, label="Parameters", help_text="JSON payload for workflow input"
+    )
+
+
+class SignalWorkflowForm(forms.Form):
+    signal_name = forms.CharField(label="Signal name")
+    payload = forms.JSONField(
+        required=False, label="Payload", help_text="JSON payload for the signal"
+    )
 
 
 class HistoryEventInline(admin.TabularInline):
@@ -56,6 +76,60 @@ class WorkflowExecutionAdmin(admin.ModelAdmin):
         'updated_at',
     )
     inlines = [ActivityTaskInline, HistoryEventInline]
+
+    actions = ["cancel_workflows", "signal_workflows"]
+
+    def add_view(self, request, form_url="", extra_context=None):
+        if request.method == "POST":
+            form = StartWorkflowForm(request.POST)
+            if form.is_valid():
+                name = form.cleaned_data["workflow_name"]
+                params = form.cleaned_data.get("params") or {}
+                exec_id = start_workflow(name, **params)
+                self.message_user(request, f"Started workflow {exec_id}")
+                url = reverse("admin:django_durable_workflowexecution_change", args=[exec_id])
+                return redirect(url)
+        else:
+            form = StartWorkflowForm()
+        context = {
+            **self.admin_site.each_context(request),
+            "form": form,
+            "opts": self.model._meta,
+            "title": "Start workflow",
+        }
+        return TemplateResponse(request, "admin/django_durable/start_workflow.html", context)
+
+    @admin.action(description="Cancel selected workflows")
+    def cancel_workflows(self, request, queryset):
+        for execution in queryset:
+            cancel_workflow(execution)
+        self.message_user(request, f"Canceled {queryset.count()} workflow(s)")
+
+    @admin.action(description="Signal selected workflows")
+    def signal_workflows(self, request, queryset):
+        form = SignalWorkflowForm(request.POST or None)
+        if "apply" in request.POST:
+            if form.is_valid():
+                name = form.cleaned_data["signal_name"]
+                payload = form.cleaned_data.get("payload")
+                for execution in queryset:
+                    signal_workflow(execution, name, payload)
+                self.message_user(
+                    request, f"Sent signal '{name}' to {queryset.count()} workflow(s)"
+                )
+                return None
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "form": form,
+            "queryset": queryset,
+            "action": "signal_workflows",
+            "title": "Signal workflows",
+            "action_checkbox_name": ACTION_CHECKBOX_NAME,
+        }
+        return TemplateResponse(
+            request, "admin/django_durable/signal_workflow.html", context
+        )
 
 
 @admin.register(ActivityTask)

--- a/django_durable/templates/admin/django_durable/signal_workflow.html
+++ b/django_durable/templates/admin/django_durable/signal_workflow.html
@@ -1,0 +1,15 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+  <h1>Signal workflows</h1>
+  <form method="post">{% csrf_token %}
+    {{ form.as_p }}
+    {% for obj in queryset %}
+      <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="{{ action }}">
+    <input type="hidden" name="select_across" value="0">
+    <input type="submit" name="apply" value="Send">
+  </form>
+{% endblock %}
+

--- a/django_durable/templates/admin/django_durable/start_workflow.html
+++ b/django_durable/templates/admin/django_durable/start_workflow.html
@@ -1,0 +1,10 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+  <h1>Start workflow</h1>
+  <form method="post">{% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Start">
+  </form>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- allow starting workflows from the admin via a custom form
- add admin actions to signal or cancel workflow executions
- provide templates for start and signal interstitial forms

## Testing
- `ruff check .`
- `isort --check-only .`
- `mypy` *(fails: Dict entry 1 has incompatible type "str": "Path"; expected "str": "str" [dict-item])* 
- `python manage.py migrate --noinput`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b863c696b8833099bf215d6f6947ee