### PR TITLE
Modernize type hints for Python 3.10

### DIFF
--- a/django_durable/api.py
+++ b/django_durable/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from .engine import (
     _run_workflow,
@@ -19,14 +19,14 @@ __all__ = [
     "register",
 ]
 
-def start_workflow(workflow_name: str, timeout: Optional[float] = None, **inputs) -> str:
+def start_workflow(workflow_name: str, timeout: float | None = None, **inputs) -> str:
     """Create a workflow execution and return its handle (ID)."""
     return _start_workflow(workflow_name, timeout=timeout, **inputs)
 
-def wait_workflow(execution: Union[WorkflowExecution, str]) -> Any:
+def wait_workflow(execution: WorkflowExecution | str) -> Any:
     """Wait for a workflow execution to complete and return its result."""
     return _wait_workflow(execution)
 
-def run_workflow(workflow_name: str, timeout: Optional[float] = None, **inputs) -> Any:
+def run_workflow(workflow_name: str, timeout: float | None = None, **inputs) -> Any:
     """Convenience helper: start a workflow and wait for its result."""
     return _run_workflow(workflow_name, timeout=timeout, **inputs)

--- a/django_durable/checks.py
+++ b/django_durable/checks.py
@@ -1,7 +1,6 @@
 import ast
 import inspect
 import textwrap
-from typing import List
 
 from django.core import checks
 
@@ -37,7 +36,7 @@ def _full_name(node: ast.AST) -> str:
 
 @checks.register()
 def check_workflow_determinism(app_configs, **kwargs):
-    errors: List[checks.CheckMessage] = []
+    errors: list[checks.CheckMessage] = []
 
     for name, fn in register.workflows.items():
         try:

--- a/django_durable/registry.py
+++ b/django_durable/registry.py
@@ -1,6 +1,6 @@
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Dict, Optional
 
 from django.apps import apps
 
@@ -9,8 +9,8 @@ from .retry import RetryPolicy
 
 class Register:
     def __init__(self):
-        self.workflows: Dict[str, Callable] = {}
-        self.activities: Dict[str, Callable] = {}
+        self.workflows: dict[str, Callable] = {}
+        self.activities: dict[str, Callable] = {}
 
     def _durable_name(self, fn: Callable) -> str:
         module = sys.modules.get(fn.__module__)
@@ -26,7 +26,7 @@ class Register:
             app_name = fn.__module__.split('.')[0]
         return f"{app_name}.{fn.__name__}"
 
-    def workflow(self, timeout: Optional[float] = None):
+    def workflow(self, timeout: float | None = None):
         def deco(fn):
             if timeout is not None:
                 fn._durable_timeout = timeout
@@ -39,9 +39,9 @@ class Register:
 
     def activity(
         self,
-        timeout: Optional[float] = None,
-        heartbeat_timeout: Optional[float] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        timeout: float | None = None,
+        heartbeat_timeout: float | None = None,
+        retry_policy: RetryPolicy | None = None,
     ):
         def deco(fn):
             rp = retry_policy or RetryPolicy()

--- a/django_durable/retry.py
+++ b/django_durable/retry.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import random
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Mapping
+from typing import Any
 
 
 def compute_backoff(policy: Mapping[str, float], attempt: int) -> float:
@@ -48,9 +47,9 @@ class RetryPolicy:
     maximum_attempts: int = 0  # 0 for unlimited
     jitter: float = 0.0
     strategy: str = "exponential"
-    non_retryable_error_types: List[str] = field(default_factory=list)
+    non_retryable_error_types: list[str] = field(default_factory=list)
 
-    def asdict(self) -> Dict:
+    def asdict(self) -> dict[str, Any]:
         return asdict(self)
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,7 @@ exec_id = start_workflow("myapp.onboard_user", user_id=7)
 ```
 
 - Summary: Block until the workflow completes and return its result.
-- Params: `execution: Union[WorkflowExecution, str]`
+- Params: `execution: WorkflowExecution | str`
 - Returns: JSON-serializable result
 - Example:
 
@@ -45,7 +45,7 @@ result = wait_workflow(exec_id)
 ```
 
 - Summary: Enqueue an external signal for a workflow and mark it runnable.
-- Params: `execution: Union[WorkflowExecution, str]`, `name: str`, `payload: Any = None`
+- Params: `execution: WorkflowExecution | str`, `name: str`, `payload: Any | None = None`
 - Returns: `None`
 - Example:
 
@@ -58,7 +58,7 @@ signal_workflow(exec_id, "go", {"clicked": True})
 ```
 
 - Summary: Cancel a workflow execution and optionally fail queued activities.
-- Params: `execution: Union[WorkflowExecution, str]`, `reason: str | None = None`, `cancel_queued_activities: bool = True`
+- Params: `execution: WorkflowExecution | str`, `reason: str | None = None`, `cancel_queued_activities: bool = True`
 - Returns: `None`
 - Example:
 

--- a/testproj/stress.py
+++ b/testproj/stress.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 MANAGE = str(ROOT / "manage.py")
@@ -22,7 +22,7 @@ def run_manage(*args: str) -> str:
     return res.stdout.strip()
 
 
-def read_workflow(exec_id: str) -> Dict[str, Any]:
+def read_workflow(exec_id: str) -> dict[str, Any]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
@@ -40,7 +40,7 @@ def read_workflow(exec_id: str) -> Dict[str, Any]:
         con.close()
 
 
-def read_activity_statuses(exec_id: str) -> List[str]:
+def read_activity_statuses(exec_id: str) -> list[str]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
@@ -66,7 +66,7 @@ def run_worker(iterations: int = 50) -> None:
     )
 
 
-WORKFLOWS: List[Dict[str, Any]] = [
+WORKFLOWS: list[dict[str, Any]] = [
     {
         "name": "testproj.add_flow",
         "input": {"a": 1, "b": 2},
@@ -138,7 +138,7 @@ WORKFLOWS: List[Dict[str, Any]] = [
 ]
 
 
-def run_workflow(spec: Dict[str, Any]) -> None:
+def run_workflow(spec: dict[str, Any]) -> None:
     out = run_manage(
         "durable_start",
         spec["name"],

--- a/testproj/tests/test_e2e.py
+++ b/testproj/tests/test_e2e.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any
 
 import pytest
 import sqlite3
@@ -29,7 +29,7 @@ def migrate_db() -> None:
     run_manage("migrate", "--noinput")
 
 
-def read_workflow(exec_id: str) -> Tuple[str, Any]:
+def read_workflow(exec_id: str) -> tuple[str, Any]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
@@ -51,7 +51,7 @@ def read_workflow(exec_id: str) -> Tuple[str, Any]:
         con.close()
 
 
-def read_activity_statuses(exec_id: str) -> List[str]:
+def read_activity_statuses(exec_id: str) -> list[str]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()


### PR DESCRIPTION
## Summary
- use builtin generic types and PEP 604 unions
- document API with Python 3.10 style type hints

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68b9a2ce88708330b8e7639bffe13d22