### PR TITLE
Avoid direct sleep in test workflows

### DIFF
--- a/testproj/durable_workflows.py
+++ b/testproj/durable_workflows.py
@@ -1,5 +1,3 @@
-import time
-
 from django_durable import register
 from .durable_activities import (
     add,
@@ -114,9 +112,9 @@ def parent_child_workflow(ctx, x: int):
 
 @register.workflow()
 def long_running_step_flow(ctx, loops: int, delay: float):
-    """Workflow with long-running steps to test recovery when worker dies mid-execution."""
+    """Workflow with long-running activities to test recovery when worker dies mid-execution."""
     for i in range(loops):
-        time.sleep(delay)
+        ctx.run_activity(slow_sleep, delay)
         ctx.run_activity(do_work, i)
     return {"done": loops}
 

--- a/testproj/tests/test_timeouts_retries.py
+++ b/testproj/tests/test_timeouts_retries.py
@@ -2,7 +2,6 @@ import json
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import pytest
@@ -84,8 +83,15 @@ def test_workflow_timeout(tmp_path):
         "0.1",
     )
     exec_id = out.splitlines()[-1].strip()
-    time.sleep(0.2)
-    run_manage("durable_worker", "--batch", "50", "--tick", "0.01", "--iterations", "20")
+    run_manage(
+        "durable_worker",
+        "--batch",
+        "50",
+        "--tick",
+        "0.01",
+        "--iterations",
+        "20",
+    )
     status, _ = read_workflow(exec_id)
     assert status == "TIMED_OUT"
 


### PR DESCRIPTION
## Summary
- Replace direct `time.sleep` calls in `long_running_step_flow` with `slow_sleep` activity
- Remove test usage of `time.sleep` by letting the worker loop handle timeout

## Testing
- ⚠️ `nox -s lint tests` (missing `django_durable.management`)
- ✅ `python manage.py migrate --noinput`
- ✅ `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9c058df088330afdc9724a7d3308f