### PR TITLE
Ensure Django Durable management commands are packaged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dev = [
     "myst-parser>=2.0",
 ]
 
-[tool.setuptools]
-packages = ["django_durable"]
+[tool.setuptools.packages.find]
+include = ["django_durable*"]
 
 [build-system]
 requires = ["setuptools>=61", "wheel"]


### PR DESCRIPTION
## Summary
- Include all `django_durable` subpackages in the distribution so management commands are installed

## Testing
- `uv run nox -s lint`
- `uv run nox -s tests`
- `uv run nox -s docs`


------
https://chatgpt.com/codex/tasks/task_e_68b9c4b52ad08330977103760542a5f8