### PR TITLE
Switch workflow IDs to auto-increment primary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python manage.py durable_worker --batch 20 --tick 0.2 --procs 4
 - To send a signal from outside code:
 
 ```bash
-python manage.py durable_signal <execution_uuid> user_clicked --input '{"clicked": true}'
+python manage.py durable_signal <execution_id> user_clicked --input '{"clicked": true}'
 ```
 
 You can also send a signal programmatically:
@@ -38,7 +38,7 @@ signal_workflow(execution_id, "user_clicked", {"clicked": True})
 - Cancel a workflow via CLI:
 
 ```bash
-python manage.py durable_cancel <execution_uuid> --reason "user requested" [--keep-queued]
+python manage.py durable_cancel <execution_id> --reason "user requested" [--keep-queued]
 ```
 
 - In code:

--- a/django_durable/management/commands/durable_cancel.py
+++ b/django_durable/management/commands/durable_cancel.py
@@ -8,7 +8,7 @@ class Command(BaseCommand):
     help = 'Cancel a workflow execution and its queued activities.'
 
     def add_arguments(self, parser):
-        parser.add_argument('execution_id', help='WorkflowExecution UUID')
+        parser.add_argument('execution_id', help='WorkflowExecution ID')
         parser.add_argument(
             '--reason', default='', help='Optional cancellation reason (string)'
         )

--- a/django_durable/management/commands/durable_signal.py
+++ b/django_durable/management/commands/durable_signal.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
     help = 'Send a signal to a workflow execution.'
 
     def add_arguments(self, parser):
-        parser.add_argument('execution_id', help='WorkflowExecution UUID')
+        parser.add_argument('execution_id', help='WorkflowExecution ID')
         parser.add_argument('signal_name', help='Signal name')
         parser.add_argument(
             '--input',

--- a/django_durable/migrations/0001_initial.py
+++ b/django_durable/migrations/0001_initial.py
@@ -2,7 +2,6 @@
 
 import django.db.models.deletion
 import django.utils.timezone
-import uuid
 from django.db import migrations, models
 
 
@@ -18,11 +17,11 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.UUIDField(
-                        default=uuid.uuid4,
-                        editable=False,
+                    models.BigAutoField(
+                        auto_created=True,
                         primary_key=True,
                         serialize=False,
+                        verbose_name="ID",
                     ),
                 ),
                 ("workflow_name", models.CharField(max_length=200)),
@@ -92,11 +91,11 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.UUIDField(
-                        default=uuid.uuid4,
-                        editable=False,
+                    models.BigAutoField(
+                        auto_created=True,
                         primary_key=True,
                         serialize=False,
+                        verbose_name="ID",
                     ),
                 ),
                 ("activity_name", models.CharField(max_length=200)),

--- a/django_durable/models.py
+++ b/django_durable/models.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.db import models
 from django.utils import timezone
 
@@ -14,7 +12,6 @@ class WorkflowExecution(models.Model):
         CANCELED = 'CANCELED'
         TIMED_OUT = 'TIMED_OUT'
 
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     workflow_name = models.CharField(max_length=200)
     input = models.JSONField(default=dict, blank=True)
     status = models.CharField(
@@ -70,7 +67,6 @@ class ActivityTask(models.Model):
         FAILED = 'FAILED'
         TIMED_OUT = 'TIMED_OUT'
 
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     execution = models.ForeignKey(
         WorkflowExecution, related_name='activities', on_delete=models.CASCADE
     )

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ This reference lists the public surface exposed by `django_durable` and commonly
 ```{autofunction} django_durable.api.start_workflow
 ```
 
- - Summary: Create a workflow execution and return its handle (UUID string).
+ - Summary: Create a workflow execution and return its handle (ID string).
  - Params: `workflow: str | Callable`, `timeout: float | None = None`, `**inputs`
  - Returns: `str` execution ID
  - Example:
@@ -27,7 +27,7 @@ This reference lists the public surface exposed by `django_durable` and commonly
 ```
 
 - Summary: Block until the workflow completes and return its result.
-- Params: `execution: WorkflowExecution | str`
+- Params: `execution: WorkflowExecution | int | str`
 - Returns: JSON-serializable result
 - Example:
 
@@ -47,7 +47,7 @@ result = wait_workflow(exec_id)
 ```
 
 - Summary: Enqueue an external signal for a workflow and mark it runnable.
-- Params: `execution: WorkflowExecution | str`, `name: str`, `payload: Any | None = None`
+- Params: `execution: WorkflowExecution | int | str`, `name: str`, `payload: Any | None = None`
 - Returns: `None`
 - Example:
 
@@ -60,7 +60,7 @@ signal_workflow(exec_id, "go", {"clicked": True})
 ```
 
 - Summary: Cancel a workflow execution and optionally fail queued activities.
-- Params: `execution: WorkflowExecution | str`, `reason: str | None = None`, `cancel_queued_activities: bool = True`
+- Params: `execution: WorkflowExecution | int | str`, `reason: str | None = None`, `cancel_queued_activities: bool = True`
 - Returns: `None`
 - Example:
 
@@ -148,7 +148,7 @@ def my_activity():
   - `--procs`: maximum concurrent subprocesses (default 4)
 
 - `durable_start WORKFLOW_NAME [--input JSON] [--timeout FLOAT]`
-  - Starts a workflow by name with optional JSON kwargs. Prints the execution UUID.
+   - Starts a workflow by name with optional JSON kwargs. Prints the execution ID.
 
 - `durable_signal EXECUTION_ID SIGNAL_NAME [--input JSON]`
   - Sends a signal to a workflow with an optional JSON payload.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -123,7 +123,7 @@ def example_with_signal(ctx):
 Send a signal from the CLI or code:
 
 ```bash
-python manage.py durable_signal <execution_uuid> go --input '{"clicked": true}'
+   python manage.py durable_signal <execution_id> go --input '{"clicked": true}'
 ```
 
 ```python

--- a/testproj/stress.py
+++ b/testproj/stress.py
@@ -26,10 +26,9 @@ def read_workflow(exec_id: str) -> dict[str, Any]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status, result FROM django_durable_workflowexecution WHERE id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, f"Workflow not found: {exec_id}"
@@ -44,10 +43,9 @@ def read_activity_statuses(exec_id: str) -> list[str]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status FROM django_durable_activitytask WHERE execution_id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         return [r[0] for r in cur.fetchall()]
     finally:

--- a/testproj/tests/test_child_workflow.py
+++ b/testproj/tests/test_child_workflow.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 import pytest
-import uuid
 
 ROOT = Path(__file__).resolve().parents[2]
 MANAGE = str(ROOT / "manage.py")
@@ -31,10 +30,9 @@ def read_workflow(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status, result FROM django_durable_workflowexecution WHERE id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, f"Workflow not found: {exec_id}"
@@ -52,16 +50,14 @@ def read_child(parent_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_parent = parent_id.replace('-', '')
         cur.execute(
             "SELECT id FROM django_durable_workflowexecution WHERE parent_id=?",
-            (norm_parent,),
+            (int(parent_id),),
         )
         row = cur.fetchone()
         assert row, "Child workflow not found"
-        child_id_hex = row[0]
-        child_id = str(uuid.UUID(child_id_hex))
-        return read_workflow(child_id)
+        child_id = row[0]
+        return read_workflow(str(child_id))
     finally:
         con.close()
 
@@ -70,14 +66,13 @@ def get_child_id(parent_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_parent = parent_id.replace('-', '')
         cur.execute(
             "SELECT id FROM django_durable_workflowexecution WHERE parent_id=?",
-            (norm_parent,),
+            (int(parent_id),),
         )
         row = cur.fetchone()
         assert row, "Child workflow not found"
-        return str(uuid.UUID(row[0]))
+        return str(row[0])
     finally:
         con.close()
 

--- a/testproj/tests/test_e2e.py
+++ b/testproj/tests/test_e2e.py
@@ -33,11 +33,9 @@ def read_workflow(exec_id: str) -> tuple[str, Any]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        # SQLite stores UUIDs as 32-char hex without dashes by default
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status, result FROM django_durable_workflowexecution WHERE id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, f"Workflow not found: {exec_id}"
@@ -55,10 +53,9 @@ def read_activity_statuses(exec_id: str) -> list[str]:
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status FROM django_durable_activitytask WHERE execution_id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         return [r[0] for r in cur.fetchall()]
     finally:

--- a/testproj/tests/test_heartbeats.py
+++ b/testproj/tests/test_heartbeats.py
@@ -30,10 +30,9 @@ def read_workflow(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status, result FROM django_durable_workflowexecution WHERE id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, f"Workflow not found: {exec_id}"
@@ -48,10 +47,9 @@ def read_activity(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status, heartbeat_details FROM django_durable_activitytask WHERE execution_id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         if not row:

--- a/testproj/tests/test_timeouts_retries.py
+++ b/testproj/tests/test_timeouts_retries.py
@@ -31,10 +31,9 @@ def read_workflow(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status, result FROM django_durable_workflowexecution WHERE id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, f"Workflow not found: {exec_id}"
@@ -52,10 +51,9 @@ def read_activity_statuses(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace('-', '')
         cur.execute(
             "SELECT status FROM django_durable_activitytask WHERE execution_id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         return [r[0] for r in cur.fetchall()]
     finally:

--- a/testproj/tests/test_unknown_activity.py
+++ b/testproj/tests/test_unknown_activity.py
@@ -30,10 +30,9 @@ def read_task(task_id: str):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = task_id.replace("-", "")
         cur.execute(
             "SELECT status, error FROM django_durable_activitytask WHERE id=?",
-            (norm_id,),
+            (int(task_id),),
         )
         return cur.fetchone()
     finally:

--- a/testproj/tests/test_worker_processes.py
+++ b/testproj/tests/test_worker_processes.py
@@ -26,10 +26,9 @@ def read_workflow(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace("-", "")
         cur.execute(
             "SELECT status FROM django_durable_workflowexecution WHERE id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, f"Workflow not found: {exec_id}"
@@ -42,10 +41,9 @@ def read_activity_status(exec_id):
     con = sqlite3.connect(DB_PATH)
     try:
         cur = con.cursor()
-        norm_id = exec_id.replace("-", "")
         cur.execute(
             "SELECT status FROM django_durable_activitytask WHERE execution_id=?",
-            (norm_id,),
+            (int(exec_id),),
         )
         row = cur.fetchone()
         assert row, "Activity not found"


### PR DESCRIPTION
## Summary
- drop UUID-based primary keys from `WorkflowExecution` and `ActivityTask`
- adjust commands and docs to reference numeric IDs
- update tests for integer workflow and task IDs

## Testing
- `python -m nox -s lint`
- `python -m nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68c2e21c2a3c83309497920285f79b25