### PR TITLE
Remove cancel_queued_activities parameter from cancel_workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ signal_workflow(execution_id, "user_clicked", {"clicked": True})
 - Cancel a workflow via CLI:
 
 ```bash
-python manage.py durable_cancel <execution_id> --reason "user requested" [--keep-queued]
+python manage.py durable_cancel <execution_id> --reason "user requested"
 ```
 
 - In code:
@@ -48,7 +48,7 @@ from django_durable import cancel_workflow
 cancel_workflow(execution_id, reason="user requested")
 ```
 
-Cancellation moves the workflow to CANCELED and, by default, marks queued activities as failed so workers will not run them.
+Cancellation moves the workflow to CANCELED and marks queued activities as failed so workers will not run them. Pending and running activities are canceled automatically.
 
 ## Benchmark
 

--- a/django_durable/management/commands/durable_cancel.py
+++ b/django_durable/management/commands/durable_cancel.py
@@ -5,26 +5,22 @@ from django_durable.models import WorkflowExecution
 
 
 class Command(BaseCommand):
-    help = 'Cancel a workflow execution and its queued activities.'
+    help = 'Cancel a workflow execution.'
 
     def add_arguments(self, parser):
         parser.add_argument('execution_id', help='WorkflowExecution ID')
         parser.add_argument(
             '--reason', default='', help='Optional cancellation reason (string)'
         )
-        parser.add_argument(
-            '--keep-queued', action='store_true', help='Do not fail queued activities'
-        )
 
     def handle(self, *args, **opts):
         exec_id = opts['execution_id']
         reason = opts['reason'] or None
-        keep = bool(opts['keep_queued'])
 
         try:
             wf = WorkflowExecution.objects.get(pk=exec_id)
         except WorkflowExecution.DoesNotExist:
             raise CommandError(f'WorkflowExecution not found: {exec_id}')
 
-        cancel_workflow(wf, reason=reason, cancel_queued_activities=not keep)
+        cancel_workflow(wf, reason=reason)
         self.stdout.write(self.style.SUCCESS('CANCELED'))

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,8 +59,8 @@ signal_workflow(exec_id, "go", {"clicked": True})
 ```{autofunction} django_durable.api.cancel_workflow
 ```
 
-- Summary: Cancel a workflow execution and optionally fail queued activities.
-- Params: `execution: WorkflowExecution | int | str`, `reason: str | None = None`, `cancel_queued_activities: bool = True`
+- Summary: Cancel a workflow execution and fail queued activities. Pending and running activities cancel automatically.
+- Params: `execution: WorkflowExecution | int | str`, `reason: str | None = None`
 - Returns: `None`
 - Example:
 
@@ -153,8 +153,8 @@ def my_activity():
 - `durable_signal EXECUTION_ID SIGNAL_NAME [--input JSON]`
   - Sends a signal to a workflow with an optional JSON payload.
 
-- `durable_cancel EXECUTION_ID [--reason STR] [--keep-queued]`
-  - Cancels the workflow. By default, queued activities are failed to prevent execution.
+- `durable_cancel EXECUTION_ID [--reason STR]`
+  - Cancels the workflow and fails queued activities to prevent execution.
 
 ## Settings and Conventions
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -54,7 +54,7 @@ This document explains how and why Django Durable works the way it does.
 
 - Crashes during workflow replay: replay is idempotent; a `NeedsPause` control-flow exception indicates when to yield until new checkpoints exist.
 - Crashes during activity: the task remains RUNNING; heartbeat and schedule-to-close timeouts detect stalled tasks and retry or mark them timed out.
-- Cancellation: `cancel_workflow` sets status to CANCELED, records events, and (by default) fails queued activities to prevent later execution. Child workflows are canceled recursively.
+- Cancellation: `cancel_workflow` sets status to CANCELED, records events, and fails queued activities to prevent later execution. Child workflows and active activities are canceled automatically.
 - Versioning: `ctx.get_version`, `ctx.patched`, and `ctx.deprecate_patch` enable safe migration of workflow logic while preserving determinism for in-flight executions.
 
 ## Comparison Notes


### PR DESCRIPTION
## Summary
- always cancel queued activities on `cancel_workflow`
- drop `--keep-queued` flag from `durable_cancel` command
- update documentation to reflect automatic activity cancellation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2e69786288330b50cbccf744a8c16