### PR TITLE
feat: support conditional patches

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -123,7 +123,9 @@ Each workflow function receives `ctx`, which exposes deterministic APIs used dur
 - `ctx.wait_workflow(handle: str, timeout: float | None = None) -> Any`: wait for a child workflow by handle.
 - Versioning helpers:
   - `ctx.get_version(change_id: str, version: int) -> int`
-  - `ctx.patched(change_id: str) -> bool`
+  - `ctx.patched(change_id: str) -> bool`: returns `True` for new executions and
+    `False` for workflows that already progressed beyond the patched location,
+    enabling `if`/`else` branches for rolling out changes.
   - `ctx.deprecate_patch(change_id: str) -> None`
 
 These methods are deterministic: on replay, they consult the `HistoryEvent` log to return prior results.


### PR DESCRIPTION
## Summary
- add Temporal-style conditional patching via `Context.patched`
- allow multiple queued workflow signals
- test patch behavior for existing vs new workflows

## Testing
- `uv run nox -s lint`
- `uv run nox -s tests` *(fails: test_activity_heartbeat_timeout expected FAILED status)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e9f4b23c8330b1daf67e098254fa